### PR TITLE
remove cyrale/linuxgsm as a required base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+WORKDIR /home/steam/linuxgsm
+
 # Stop apt-get asking to get Dialog frontend
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
@@ -27,18 +29,28 @@ RUN dpkg --add-architecture i386 && \
         tmux \
         util-linux \
         unzip \
-        wget && \
-    apt-get -y autoremove && \
+        wget
+
+# Debug tools
+RUN apt-get install -y netcat iputils-ping dnsutils traceroute iptables vim 
+
+# Cleanup 
+RUN apt-get -y autoremove && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/*
+
+RUN  mkdir ~/bin \
+  && curl -sSLf -z ~/bin/gomplate -o ~/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v2.2.0/gomplate_linux-amd64-slim \
+  && chmod 755 ~/bin/gomplate
 
 # Add the steam user
 RUN adduser \
     --disabled-login \
     --disabled-password \
     --shell /bin/bash \
+    --gecos "" \
     steam
 
 # Select the script as entry point
@@ -54,23 +66,12 @@ USER steam
 RUN git clone "https://github.com/GameServerManagers/LinuxGSM.git" /home/steam/linuxgsm && \
     /home/steam/update-linuxgsm.sh
 
-WORKDIR /home/steam/linuxgsm
+# RUN git fetch --all \
+#  && git reset --hard origin/master
 
-USER steam
+RUN git checkout tags/180318.1
 
-RUN git fetch --all \
- && git reset --hard origin/master
-
-RUN git checkout tags/170926.1
-
-RUN  mkdir ~/bin \
-  && curl -sSLf -z ~/bin/gomplate -o ~/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v2.2.0/gomplate_linux-amd64-slim \
-  && chmod 755 ~/bin/gomplate
-
-USER root
-
-RUN apt-get update \
- && apt-get install -y netcat iputils-ping dnsutils traceroute iptables vim 
+USER root 
  
 RUN find /home/steam/linuxgsm -type f -name "*.sh" -exec chmod u+x {} \; \
  && find /home/steam/linuxgsm -type f -name "*.py" -exec chmod u+x {} \; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,58 @@
-FROM cyrale/linuxgsm
+FROM ubuntu:16.04
+
+# Stop apt-get asking to get Dialog frontend
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM xterm
+
+# Install dependencies and clean
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y \
+        binutils \
+        bsdmainutils \
+        bzip2 \
+        curl \
+        file \
+        git \
+        gzip \
+        lib32gcc1 \
+        lib32ncurses5 \
+        lib32z1 \
+        libc6 \
+        libstdc++6 \
+        libstdc++6:i386 \
+        mailutils \
+        postfix \
+        python \
+        tmux \
+        util-linux \
+        unzip \
+        wget && \
+    apt-get -y autoremove && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/*
+
+# Add the steam user
+RUN adduser \
+    --disabled-login \
+    --disabled-password \
+    --shell /bin/bash \
+    steam
+
+# Select the script as entry point
+COPY ./update-linuxgsm.sh /home/steam/
+RUN [ -d /home/steam/linuxgsm ] || mkdir -p /home/steam/linuxgsm && \
+    chown -R steam:steam /home/steam && \
+    chmod u+x /home/steam/update-linuxgsm.sh
+
+# Switch to the user steam
+USER steam
+
+# Install LinuxGSM
+RUN git clone "https://github.com/GameServerManagers/LinuxGSM.git" /home/steam/linuxgsm && \
+    /home/steam/update-linuxgsm.sh
 
 WORKDIR /home/steam/linuxgsm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,18 +53,13 @@ RUN adduser \
     --gecos "" \
     steam
 
-# Select the script as entry point
-COPY ./update-linuxgsm.sh /home/steam/
-RUN [ -d /home/steam/linuxgsm ] || mkdir -p /home/steam/linuxgsm && \
-    chown -R steam:steam /home/steam && \
-    chmod u+x /home/steam/update-linuxgsm.sh
+RUN chown -R steam:steam /home/steam
 
 # Switch to the user steam
 USER steam
 
 # Install LinuxGSM
-RUN git clone "https://github.com/GameServerManagers/LinuxGSM.git" /home/steam/linuxgsm && \
-    /home/steam/update-linuxgsm.sh
+RUN git clone "https://github.com/GameServerManagers/LinuxGSM.git" /home/steam/linuxgsm 
 
 # RUN git fetch --all \
 #  && git reset --hard origin/master


### PR DESCRIPTION
The current `cyrale/linuxgsm` base image is very outdated and it would be wise to just install everything myself