### PR TITLE
Swarm tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ swarm_test: &swarm_test
     command: | 
       docker swarm init
       docker stack deploy --compose-file ./docker-stack.yml game
-      retry -v -s 5 -x 120 'docker exec $(docker ps -q) "./docker-health.sh"''
+      retry -v -s 5 -x 120 'docker exec $(docker ps -q) "./docker-health.sh"'
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,6 @@ workflows:
       - compose-css:
           requires:
             - build
-      - compose-gmod:
-          requires:
-            - build
+      # - compose-gmod:
+      #     requires:
+      #       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ swarm_test: &swarm_test
     name: Start container & run tests
     command: | 
       docker swarm init
-      retry -v -s 5 -x 120 "docker stack deploy --compose-file ./docker-stack.yml game"
-      docker exec $(docker ps -q) "./docker-health.sh"
+      docker stack deploy --compose-file ./docker-stack.yml game
+      retry -v -s 5 -x 120 docker exec $(docker ps -q) "./docker-health.sh"
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ swarm_test: &swarm_test
     name: Start container & run tests
     command: | 
       docker swarm init
-      retry -v -s 5 -x 120 docker stack deploy --compose-file ./docker-stack.yml game
+      retry -v -s 5 -x 120 "docker stack deploy --compose-file ./docker-stack.yml game"
       docker exec $(docker ps -q) "./docker-health.sh"
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ swarm_test: &swarm_test
     name: Start container & run tests
     command: | 
       docker swarm init
-      sleep 10
-      docker stack deploy --compose-file ./docker-stack.yml game
-      sleep 60
+      retry -v -s 5 -x 120 docker stack deploy --compose-file ./docker-stack.yml game
       docker exec $(docker ps -q) "./docker-health.sh"
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ swarm_test: &swarm_test
       docker swarm init
       docker stack deploy --compose-file ./docker-stack.yml game
       retry -v -s 5 -x 120 -t 1000 'docker exec $(docker ps -q) "./docker-ready.sh"'
-      docker exec $(docker ps -q) "./docker-health.sh"
+      retry -v -s 5 -x 120 -t 1000 'docker exec $(docker ps -q) "./docker-health.sh"'
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ swarm_test: &swarm_test
     command: | 
       docker swarm init
       docker stack deploy --compose-file ./docker-stack.yml game
-      retry -v -s 5 -x 120 'docker exec $(docker ps -q) "./docker-ready.sh"'
+      retry -v -s 5 -x 120 -t 1000 'docker exec $(docker ps -q) "./docker-ready.sh"'
       docker exec $(docker ps -q) "./docker-health.sh"
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,7 @@ jobs:
       - run: docker load -i /tmp/workspace/images.tar
       - run: cp /tmp/workspace/docker-stack.yml ./docker-stack.yml
       - run:
-          name: Start Stack
-          command: | 
-            <<: *swarm_test
+          <<: *swarm_test
   compose:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ compose_test: &compose_test
       docker-compose up -d
       sleep 60
       docker-compose exec game  "./docker-health.sh"
+swarm_test: &swarm_test
+    name: Start container & run tests
+    command: | 
+      docker swarm init
+      sleep 10
+      docker stack deploy --compose-file ./docker-stack.yml game
+      sleep 60
+      docker exec $(docker ps -q) "./docker-health.sh"
 version: 2
 jobs:
   build:
@@ -43,24 +51,11 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: docker load -i /tmp/workspace/images.tar
+      - run: cp /tmp/workspace/docker-stack.yml ./docker-stack.yml
       - run:
           name: Start Stack
           command: | 
-            docker swarm init
-            sleep 10
-            docker stack deploy --compose-file /tmp/workspace/docker-stack.yml game
-      - run:
-          name: Delay a little bit
-          command: sleep 60
-      - run: 
-          name: Inspect things
-          command: |
-            docker ps
-            docker logs $(docker ps -q)
-      - run:
-          name: Test Swarm
-          command: |
-            docker exec $(docker ps -q) "./docker-health.sh"
+            <<: *swarm_test
   compose:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ compose_test: &compose_test
     name: Start container & run tests
     command: | 
       docker-compose up -d
-      sleep 60
-      docker-compose exec game  "./docker-health.sh"
+      retry -v -s 5 -x 120 -t 1000 'docker-compose exec game "./docker-ready.sh"'
+      retry -v -s 5 -x 120 -t 1000 'docker-compose exec game "./docker-health.sh"'
 swarm_test: &swarm_test
     name: Start container & run tests
     command: | 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ swarm_test: &swarm_test
     command: | 
       docker swarm init
       docker stack deploy --compose-file ./docker-stack.yml game
-      retry -v -s 5 -x 120 'docker exec $(docker ps -q) "./docker-health.sh"'
+      retry -v -s 5 -x 120 'docker exec $(docker ps -q) "./docker-ready.sh"'
+      docker exec $(docker ps -q) "./docker-health.sh"
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ swarm_test: &swarm_test
     command: | 
       docker swarm init
       docker stack deploy --compose-file ./docker-stack.yml game
-      retry -v -s 5 -x 120 docker exec $(docker ps -q) "./docker-health.sh"
+      retry -v -s 5 -x 120 'docker exec $(docker ps -q) "./docker-health.sh"''
 version: 2
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,10 @@ RUN chown -R steam:steam /home/steam/linuxgsm \
  && chmod -R 777 /home/steam/linuxgsm \
  && ls -ltr
 
-ADD docker-runner.sh docker-health.sh ./
+ADD docker-runner.sh docker-health.sh docker-ready.sh ./
 
-RUN chown steam:steam docker-runner.sh docker-health.sh \
- && chmod +x docker-runner.sh docker-health.sh
+RUN chown steam:steam docker-runner.sh docker-health.sh docker-ready.sh \
+ && chmod +x docker-runner.sh docker-health.sh docker-ready.sh
 
 ADD functions/*.sh /home/steam/linuxgsm/lgsm/functions/
 

--- a/docker-ready.sh
+++ b/docker-ready.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f 'INSTALLING.LOCK' ]; then
+   echo "Found INSTALLING.LOCK - still installing - FAIL"
+   exit 1
+fi


### PR DESCRIPTION
The `docker-health.sh` will return true when installing. which made the previous tests sorta useless. 

This will now properly check to see if the install is done before checking the health.

the `docker-ready.sh` could be improved to also call `docker-health`. but that's pretty minor 