### PR TITLE
Update to the latest parse-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get -y autoremove && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/*
 
-COPY --from=joshhsoj1902/parse-env:1.0.2 /go/src/github.com/joshhsoj1902/parse-env/main /usr/bin/parse-env
+COPY --from=joshhsoj1902/parse-env:1.0.3 /go/src/github.com/joshhsoj1902/parse-env/main /usr/bin/parse-env
 COPY --from=hairyhenderson/gomplate:v3.1.0-alpine /bin/gomplate /usr/bin/gomplate
 
 # Add the linuxgsm user

--- a/common.cfg.tmpl
+++ b/common.cfg.tmpl
@@ -4,6 +4,16 @@
 # PLACE COMMON SETTINGS HERE
 #
 
+{{if (datasource "env").Envs}}
+
+{{ range (datasource "env").Envs -}}
+{{ .name }}={{ .value }}
+{{ end }}
+
+{{else}}
+
 {{ range (datasource "env").envs -}}
 {{ .name }}={{ .value }}
 {{ end }}
+
+{{end}}


### PR DESCRIPTION
I thought I had fixed this but maybe I messed up my releases. Hopefully, this one writes out the file with the proper lowercase `env`