### PR TITLE
Fix WorkShop Env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This image uses environment variables for configuration, below is a list of the 
 | LGSM_JAVARAM           | || Minecraft |
 | LGSM_DEFAULTMAP        | Not tested || Gmod |
 | LGSM_GAMEMODE          | Not tested || Gmod |
-| LGSM_WORKSHOPAUTH      | Not tested || Gmod |
-| LGSM_WORKSHOPCOLLECTIONID | Not tested ||Gmod|
+| LGSM_WSAPIKEY      | Not tested || Gmod |
+| LGSM_WSCOLLECTIONID | Not tested ||Gmod|
 | LGSM_ANSI              | Not tested |||
 | LGSM_BRANCH            | Not tested |||
 | LGSM_EMAILALERT        | Not tested |||


### PR DESCRIPTION
WorkShop env vars were out of date

https://github.com/GameServerManagers/LinuxGSM/commit/d0ed7c2cb74f86b7d07127ec0672fbad5a625d15#diff-8c1f51c67bbde7a989e106d6d641910c

@DukeVenator Ran into over in #115 and I just did too. I'm still working on testing this, but assuming this works I'll merge the docs update