### PR TITLE
enable csgo test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,9 +119,6 @@ workflows:
           requires:
             - swarm-test
             - compose-test  
-          filters:
-            branches:
-              only: master
     ### CSS ###    
       - docker/container-health:
           name: css-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,8 @@ workflows:
                 composeFilePath: /tmp/workspace/examples/docker-compose.7dtd.yml
                 service: game
                 command: ./docker-readiness.sh
-                sleep: 10
-                tries: 80
+                sleep: 30
+                tries: 30
           requires:
             - swarm-test
             - compose-test 
@@ -114,8 +114,8 @@ workflows:
                 composeFilePath: /tmp/workspace/examples/docker-compose.csgo.yml
                 service: game
                 command: ./docker-readiness.sh
-                sleep: 10
-                tries: 80
+                sleep: 30
+                tries: 30
           requires:
             - swarm-test
             - compose-test  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ swarm_test: &swarm_test
     command: | 
       docker swarm init
       docker stack deploy --compose-file ./docker-stack.yml game
+      sleep 30
       retry -v -s 5 -t 12 'docker exec $(docker ps -q) "./docker-liveness.sh"'
       retry -v -s 5 -t 60 'docker exec $(docker ps -q) "./docker-readiness.sh"'
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
                 service: game
                 command: ./docker-readiness.sh
                 sleep: 30
-                tries: 30
+                tries: 60
           requires:
             - swarm-test
             - compose-test  


### PR DESCRIPTION
The csgo test would only run against master, which was great to save build time, but when it fails on master everytime it's not all that useful anymore. So instead test it everytime 