### PR TITLE
Persist the Data folder to volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,15 @@ ADD --chown=linuxgsm:linuxgsm config-game-template/ /home/linuxgsm/linuxgsm/lgsm
 
 USER linuxgsm
 
-# I'm not sure what `serverfiles/Saves` is created here for...
-RUN mkdir logs serverfiles serverfiles/Saves
+RUN mkdir logs serverfiles 
+
+# This dir shouldn't be used anymore, use Saves instead
+RUN mkdir serverfiles/Saves
+
+# serverfiles/Saves is meant to be a common place to put save files when a server supports putting the files somewhere.
+# Creating this folder now works around https://github.com/docker/compose/issues/3270
+RUN mkdir Saves
+
 
 HEALTHCHECK --start-period=60s --timeout=300s --interval=60s --retries=3 CMD ./docker-liveness.sh
 

--- a/config-game-template/7DaysToDie/serverconfig.xml.tmpl
+++ b/config-game-template/7DaysToDie/serverconfig.xml.tmpl
@@ -37,8 +37,8 @@
 
 	<!-- Folder and file locations -->
 	<property name="AdminFileName"			        value="{{getenv "LGSM_ADMIN_FILE_NAME" "serveradmin.xml"}}"/>	                <!-- Server admin file name. Path relative to the SaveGameFolder -->
-    <property name="UserDataFolder"                 value="{{getenv "LGSM_USER_DATA_FOLDER" "/home/linuxgsm/linuxgsm/serverfiles/Data"}}" />	        <!-- Use this to override where the server stores all generated data, including RWG generated worlds. Do not forget to uncomment the entry! -->
-    <property name="SaveGameFolder"                 value="{{getenv "LGSM_SAVE_GAME_FOLDER" "/home/linuxgsm/linuxgsm/serverfiles/Saves"}}" />	        <!-- Use this to only override the save game path. Do not forget to uncomment the entry! -->
+  <property name="UserDataFolder"             value="{{getenv "LGSM_USER_DATA_FOLDER" "/home/linuxgsm/linuxgsm/serverfiles/Data"}}" />	        <!-- Use this to override where the server stores all generated data, including RWG generated worlds. Do not forget to uncomment the entry! -->
+  <property name="SaveGameFolder"             value="{{getenv "LGSM_SAVE_GAME_FOLDER" "/home/linuxgsm/linuxgsm/serverfiles/Saves"}}" />	        <!-- Use this to only override the save game path. Do not forget to uncomment the entry! -->
 
 
 	<!-- Other technical settings -->

--- a/config-game-template/7DaysToDie/serverconfig.xml.tmpl
+++ b/config-game-template/7DaysToDie/serverconfig.xml.tmpl
@@ -37,7 +37,7 @@
 
 	<!-- Folder and file locations -->
 	<property name="AdminFileName"			        value="{{getenv "LGSM_ADMIN_FILE_NAME" "serveradmin.xml"}}"/>	                <!-- Server admin file name. Path relative to the SaveGameFolder -->
-	<!-- <property name="UserDataFolder"				    value="absolute path" />	Use this to override where the server stores all generated data, including RWG generated worlds. Do not forget to uncomment the entry! -->
+    <property name="UserDataFolder"                 value="{{getenv "LGSM_USER_DATA_FOLDER" "/home/linuxgsm/linuxgsm/serverfiles/Data"}}" />	        <!-- Use this to override where the server stores all generated data, including RWG generated worlds. Do not forget to uncomment the entry! -->
     <property name="SaveGameFolder"                 value="{{getenv "LGSM_SAVE_GAME_FOLDER" "/home/linuxgsm/linuxgsm/serverfiles/Saves"}}" />	        <!-- Use this to only override the save game path. Do not forget to uncomment the entry! -->
 
 

--- a/examples/docker-compose.7dtd.yml
+++ b/examples/docker-compose.7dtd.yml
@@ -1,6 +1,7 @@
 version: '3.1'
 volumes:
   saves:
+  data:
 services:
   game:
     image: joshhsoj1902/linuxgsm-docker:latest
@@ -20,3 +21,4 @@ services:
       - LGSM_EAC_ENABLED=false
     volumes:
       - saves:/home/linuxgsm/linuxgsm/serverfiles/Saves
+      - data:/home/linuxgsm/linuxgsm/serverfiles/Data

--- a/examples/docker-compose.7dtd.yml
+++ b/examples/docker-compose.7dtd.yml
@@ -1,7 +1,6 @@
 version: '3.1'
 volumes:
   saves:
-  data:
 services:
   game:
     image: joshhsoj1902/linuxgsm-docker:latest
@@ -20,5 +19,4 @@ services:
       - LGSM_GAME_WORLD=RWG
       - LGSM_EAC_ENABLED=false
     volumes:
-      - saves:/home/linuxgsm/linuxgsm/serverfiles/Saves
-      - data:/home/linuxgsm/linuxgsm/serverfiles/Data
+      - saves:/home/linuxgsm/linuxgsm/Saves


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE FOR 7 DAYS TO DIE**

The data folder seems to only hold generated data (based off the seed), It will be regenerated if it's ever lost, but that takes 10 minutes on my slow laptop, so instead lets easily persist it to a volume!

In order to persist this folder I'm sticking it under the `Saves` folder which I originally created as a folder to put save files in. 7tdt also uses a folder called Saves, so to avoid confusion, I created a new `Saves` dir to the root `linuxgsm` folder. 

```
linuxgsm@0fd90f2891ed:~/linuxgsm/Saves$ ls -ltr
total 8
drwxr-xr-x 3 linuxgsm linuxgsm 4096 Oct 29 10:33 Data
drwxr-xr-x 3 linuxgsm linuxgsm 4096 Oct 29 10:34 Saves
```

This is all because of https://github.com/docker/compose/issues/3270

If a volume is mounted to a folder, and neither folder or the volume exist yet, the folder will end up owned as root. Linuxgsm runs as the user `linuxgsm` and it can't write to that dir.

The other option that I had was to create these folders during the docker build, which would work, but I would need to create the folders for each and every game server. I do think that I'll need to do that at some point, but for now using a pre-created directory when I can is best I think