### PR TITLE
minor 7dtd updates

### DIFF
--- a/config-game-template/7DaysToDie/serverconfig.xml.tmpl
+++ b/config-game-template/7DaysToDie/serverconfig.xml.tmpl
@@ -10,7 +10,11 @@
 	<property name="ServerLoginConfirmationText"	value="" />					                                            <!-- If set the user will see the message during joining the server and has to confirm it before continuing. For more complex changes to this window you can change the "serverjoinrulesdialog" window in XUi -->
 
 	<!-- Networking -->
+	{{if (getenv "LGSM_SERVER_PORT")}}
     <property name="ServerPort" 				    value="{{getenv "LGSM_SERVER_PORT" "26900"}}"/>	                        <!-- Port you want the server to listen on. -->
+	{{else}}
+    <property name="ServerPort" 				    value="{{getenv "LGSM_PORT" "26900"}}"/>	                        <!-- Port you want the server to listen on. -->
+	{{end}}
 	<property name="ServerVisibility"				value="{{getenv "LGSM_SERVER_VISIBILITY" "2"}}"/>			            <!-- Visibility of this server: 2 = public, 1 = only shown to friends, 0 = not listed. As you are never friend of a dedicated server setting this to "1" will only work when the first player connects manually by IP. -->
     <property name="ServerDisabledNetworkProtocols"	value="{{getenv "LGSM_SERVER_DISABLED_NETWORK_PROTOCOLS" "UNET"}}"/>	<!-- Networking protocols that should not be used. Separated by comma. Possible values: UNET, RakNet, SteamNetworking. Ex: "unet,steamnetworking" -->
 	<property name="ServerMaxWorldTransferSpeedKiBs" value="{{getenv "LGSM_SERVER_MAX_WORLD_TRANSFER_SPEED_KIBS" "512"}}"/>	<!-- Maximum (!) speed in kiB/s the world is transferred at to a client on first connect if it does not have the world yet. Maximum is about 1300 kiB/s, even if you set a higher value. -->

--- a/examples/docker-compose.7dtd.yml
+++ b/examples/docker-compose.7dtd.yml
@@ -1,6 +1,7 @@
 version: '3.1'
 volumes:
   saves:
+  serverfiles:
 services:
   game:
     image: joshhsoj1902/linuxgsm-docker:latest
@@ -23,3 +24,4 @@ services:
       # - LGSM_EAC_ENABLED=false
     volumes:
       - saves:/home/linuxgsm/linuxgsm/Saves
+      - serverfiles:/home/linuxgsm/linuxgsm/serverfiles


### PR DESCRIPTION
- Also Support `LGSM_PORT` for setting game port (aiming to keep this consistent across all game servers)
- Add `serverfiles` to the volume list in the example compose file to reduce unneeded redownloads