### PR TITLE
Create docker env, better stdout control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ WORKDIR /home/linuxgsm/linuxgsm
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
 
+ENV LGSM_CONSOLE_STDOUT=true
+ENV LGSM_SCRIPT_STDOUT=true
+ENV LGSM_ALERT_STDOUT=true
+ENV LGSM_GAME_STDOUT=true
+
 # Install dependencies and clean
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
@@ -87,6 +92,9 @@ ADD --chown=linuxgsm:linuxgsm common.cfg.tmpl ./lgsm/config-default/config-lgsm/
 ADD --chown=linuxgsm:linuxgsm docker-runner.sh docker-liveness.sh docker-readiness.sh ./
 ADD --chown=linuxgsm:linuxgsm lgsm/ /home/linuxgsm/linuxgsm/lgsm/
 ADD --chown=linuxgsm:linuxgsm config-game-template/ /home/linuxgsm/linuxgsm/lgsm/config-default/config-game-template/
+
+# This file isn't always created when running in docker. Ideally we shouldn't need it.
+RUN touch /.dockerenv
 
 USER linuxgsm
 

--- a/docker-runner.sh
+++ b/docker-runner.sh
@@ -107,9 +107,20 @@ sleep 30s
 sleep 5s
 ./lgsm-gameserver monitor
 
-tail -F ~/linuxgsm/log/console/lgsm-gameserver-console.log &
-tail -F ~/linuxgsm/log/script/lgsm-gameserver-script.log &
-tail -F ~/linuxgsm/log/script/lgsm-gameserver-alert.log &
-tail -F ~/linuxgsm/log/server/output_log*.txt &
+if [ "$LGSM_CONSOLE_STDOUT" == "true" ]; then
+  tail -F ~/linuxgsm/log/console/lgsm-gameserver-console.log &
+fi
+
+if [ "$LGSM_SCRIPT_STDOUT" == "true" ]; then
+  tail -F ~/linuxgsm/log/script/lgsm-gameserver-script.log &
+fi
+
+if [ "$LGSM_ALERT_STDOUT" == "true" ]; then
+  tail -F ~/linuxgsm/log/script/lgsm-gameserver-alert.log &
+fi
+
+if [ "$LGSM_GAME_STDOUT" == "true" ]; then
+  tail -F ~/linuxgsm/log/server/output_log*.txt &
+fi
 
 wait $!


### PR DESCRIPTION
The `/.dockerenv` file is used by some of the scripts as a way to know when lgsm is running inside docker.

I just ran into a k8s env that didn't have that file inside the container... So instead of rejigging the scripts for now I'll just create the file inside the image.

Also added some new ENV vars to control which log files are output to stdout, not really sure if this works how I want, but I'll play with it more after merging