### PR TITLE
Add inital support for Medal of Honor: Allied Assault

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,22 @@ workflows:
           requires:
             - swarm-test
             - compose-test   
+    ### Medal of Honor: Allied Assault ###     
+      - docker/container-health:
+          name: mohaa-compose
+          composeFile: examples/docker-compose.mohaa.yml
+          command: docker-compose -f /tmp/workspace/examples/docker-compose.mohaa.yml up
+          service: game
+          after_test: 
+            - docker/compose-exec-retry:
+                composeFilePath: /tmp/workspace/examples/docker-compose.mohaa.yml
+                service: game
+                command: curl -f http://localhost:28080/ready
+                sleep: 5
+                tries: 60
+          requires:
+            - swarm-test
+            - compose-test   
     ### Pstbs ###   
       # - docker/container-health:
       #     name: pstbs-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
         lib32stdc++6 \
         libtinfo5:i386 \
         libsdl2-2.0-0:i386 \
+        libstdc++5:i386 \
         libgconf-2-4 \
         mailutils \
         net-tools \

--- a/examples/docker-compose.mohaa.yml
+++ b/examples/docker-compose.mohaa.yml
@@ -1,0 +1,16 @@
+# This is not fully tested
+# Does this game support Save files?
+version: '3.1'
+services:
+  game:
+    image: joshhsoj1902/linuxgsm-docker:latest
+    ports:
+      - 12203:12203/tcp
+      - 12203:12203/udp
+    environment:
+      - LGSM_GAMESERVERNAME=mohaaserver
+      - LGSM_UPDATEINSTALLSKIP=UPDATE
+      - LGSM_PORT=12203
+      - LGSM_DEFAULTMAP="dm/mohdm1"
+    volumes:
+      - "/home/linuxgsm/linuxgsm/logs"


### PR DESCRIPTION
Adding initial support for Medal of Honor: Allied Assault

I can only test that that the server itself starts. I don't know if the game have save files and I don't own the game to test connecting to it

simple usage:

```
docker-compose -f examples/docker-compose.mohaa.yml up
```