### PR TITLE
Add Github action for releasing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: joshhsoj1902/linuxgsm-docker
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,14 +174,8 @@ RUN mkdir serverfiles/Saves
 # Creating this folder now works around https://github.com/docker/compose/issues/3270
 RUN mkdir Saves
 
-ARG BUILD_DATE
-ARG VCS_REF
 ARG OS=linux
 ARG ARCH=amd64
-
-LABEL org.opencontainers.image.created=$BUILD_DATE \
-    org.opencontainers.image.revision=$VCS_REF \
-    org.opencontainers.image.source="https://github.com/joshhsoj1902/linuxgsm-docker"
 
 HEALTHCHECK --start-period=60s --timeout=300s --interval=60s --retries=3 CMD curl -f http://localhost:28080/live || exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ GOARCH ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\2/')
 build:
 	@docker build \
 		--compress \
-		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg VCS_REF=$(COMMIT) \
 		-f Dockerfile \
 		-t joshhsoj1902/linuxgsm-docker \
 		.


### PR DESCRIPTION
Dockerhub stopped supporting auto-building. this adds a github action to do essentially the same thing.